### PR TITLE
Add a constructor for autowiring dependencies

### DIFF
--- a/exercises/09_secure/Spring.md
+++ b/exercises/09_secure/Spring.md
@@ -67,8 +67,12 @@ import static org.springframework.http.HttpMethod.GET;
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
+    private final XsuaaServiceConfiguration xsuaaServiceConfiguration;
+        
     @Autowired
-    XsuaaServiceConfiguration xsuaaServiceConfiguration;
+    public SecurityConfiguration(XsuaaServiceConfiguration xsuaaServiceConfiguration) {
+        this.xsuaaServiceConfiguration = xsuaaServiceConfiguration;
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/samples/spring/src/main/java/com/sap/cp/cf/demoapps/Controller.java
+++ b/samples/spring/src/main/java/com/sap/cp/cf/demoapps/Controller.java
@@ -14,8 +14,12 @@ public class Controller {
 
 	private static final Logger logger = LoggerFactory.getLogger(Controller.class);
 
+	private final ProductRepo productRepo;
+
 	@Autowired
-	private ProductRepo productRepo;
+	public Controller(ProductRepo productRepo) {
+		this.productRepo = productRepo;
+	}
 
 	@GetMapping("/productsByParam")
 	public Collection<Product> getProductByName(@RequestParam(value = "name") String name) {


### PR DESCRIPTION
Autowiring directly on properties is not recommended anymore. Instead constructor injection should be used.